### PR TITLE
Extending unit test by validation on error message

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "5.0.103",
+        "version": "3.1.402",
         "rollForward": "latestPatch"
     }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "3.1.402",
+        "version": "5.0.103",
         "rollForward": "latestPatch"
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
@@ -27,6 +27,45 @@ namespace GuardClauses.UnitTests
             Assert.Throws<ArgumentException>("object", () => Guard.Against.Default(default(object), "object"));
         }
 
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenDefaultValueString()
+        {
+            var exception = Assert.Throws<ArgumentException>("string",
+                () => Guard.Against.Default(default(string), "string", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenDefaultValueInt()
+        {
+
+            var exception = Assert.Throws<ArgumentException>("int",
+                () => Guard.Against.Default(default(int), "int", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenDefaultValueGuid()
+        {
+            var exception = Assert.Throws<ArgumentException>("guid",
+                () => Guard.Against.Default(default(Guid), "guid", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenDefaultValueDateTime()
+        {
+            var exception = Assert.Throws<ArgumentException>("datetime",
+                () => Guard.Against.Default(default(DateTime), "datetime", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenDefaultValueObject()
+        {
+            var exception = Assert.Throws<ArgumentException>("object", () => Guard.Against.Default(default(object), "object", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
         [Theory]
         [MemberData(nameof(GetNonDefaultTestVectors))]
         public void ReturnsExpectedValueWhenGivenNonDefaultValue(object input, string name, object expected)

--- a/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstDefault.cs
@@ -59,6 +59,7 @@ namespace GuardClauses.UnitTests
                 () => Guard.Against.Default(default(DateTime), "datetime", "selfOwnErrorMessage"));
             Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
+
         [Fact]
         public void ThrowsSelfOwnErrorMessageGivenDefaultValueObject()
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstInvalidFormatTests.cs
@@ -7,12 +7,12 @@ namespace GuardClauses.UnitTests
     public class GuardAgainstInvalidFormatTests
     {
         [Theory]
-        [InlineData("12345",@"\d{1,6}")]
+        [InlineData("12345", @"\d{1,6}")]
         [InlineData("50FA", @"[0-9a-fA-F]{1,6}")]
         [InlineData("abfACD", @"[a-fA-F]{1,8}")]
-        [InlineData("DHSTRY",@"[A-Z]+")]
+        [InlineData("DHSTRY", @"[A-Z]+")]
         [InlineData("3498792", @"\d+")]
-        public void ReturnsExpectedValueGivenCorrectFormat(string input,string regexPattern)
+        public void ReturnsExpectedValueGivenCorrectFormat(string input, string regexPattern)
         {
             var result = Guard.Against.InvalidFormat(input, nameof(input), regexPattern);
             Assert.Equal(input, result);
@@ -27,6 +27,18 @@ namespace GuardClauses.UnitTests
         public void ThrowsGivenGivenIncorrectFormat(string input, string regexPattern)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat(input, nameof(input), regexPattern));
+        }
+
+        [Theory]
+        [InlineData("aaa", @"\d{1,6}")]
+        [InlineData("50XA", @"[0-9a-fA-F]{1,6}")]
+        [InlineData("2GudhUtG", @"[a-fA-F]+")]
+        [InlineData("sDHSTRY", @"[A-Z]+")]
+        [InlineData("3F498792", @"\d+")]
+        public void ThrowsSelfOwnErrorMessageGivenGivenIncorrectFormat(string input, string regexPattern)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidFormat(input, nameof(input), regexPattern, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
     }

--- a/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegative.cs
@@ -16,7 +16,7 @@ namespace GuardClauses.UnitTests
             Guard.Against.Negative(0.0, "doubleZero");
             Guard.Against.Negative(TimeSpan.Zero, "timespanZero");
         }
-        
+
         [Fact]
         public void DoesNothingGivenPositiveValue()
         {
@@ -27,11 +27,18 @@ namespace GuardClauses.UnitTests
             Guard.Against.Negative(1.0, "doubleZero");
             Guard.Against.Negative(TimeSpan.FromSeconds(1), "timespanZero");
         }
-        
+
         [Fact]
         public void ThrowsGivenNegativeIntValue()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1, "negative"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenNegativeIntValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1, "negative", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -41,9 +48,23 @@ namespace GuardClauses.UnitTests
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenNegativeLongValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1L, "negative", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenNegativeDecimalValue()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0M, "negative"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenNegativeDecimalValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0M, "negative", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -53,15 +74,37 @@ namespace GuardClauses.UnitTests
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenNegativeFloatValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0f, "negative", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenNegativeDoubleValue()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0, "negative"));
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenNegativeDoubleValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(-1.0, "negative", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenNegativeTimeSpanValue()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "negative"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenNegativeTimeSpanValue()
+        {
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Negative(TimeSpan.FromSeconds(-1), "negative", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNegativeOrZero.cs
@@ -26,9 +26,23 @@ namespace GuardClauses.UnitTests
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroIntValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0, "intZero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenZeroLongValue()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0L, "longZero"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroLongValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0L, "longZero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -38,9 +52,23 @@ namespace GuardClauses.UnitTests
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroDecimalValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0M, "decimalZero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenZeroFloatValue()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0f, "floatZero"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroFloatValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0f, "floatZero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -50,11 +78,24 @@ namespace GuardClauses.UnitTests
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroDoubleValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(0.0, "doubleZero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenZeroTimeSpanValue()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.Zero, "timespanZero"));
         }
 
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroTimeSpanValue()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NegativeOrZero(TimeSpan.Zero, "timespanZero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
 
         [Fact]
         public void ThrowsGivenNegativeIntValue()

--- a/test/GuardClauses.UnitTests/GuardAgainstNull.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNull.cs
@@ -22,6 +22,7 @@ namespace GuardClauses.UnitTests
             object obj = null!;
             Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(obj, "null"));
         }
+
         [Fact]
         public void ThrowsSelfOwnErrorMessageGivenNullValue()
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstNull.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNull.cs
@@ -1,4 +1,4 @@
-using Ardalis.GuardClauses;
+﻿using Ardalis.GuardClauses;
 using System;
 using Xunit;
 
@@ -21,6 +21,13 @@ namespace GuardClauses.UnitTests
         {
             object obj = null!;
             Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(obj, "null"));
+        }
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenNullValue()
+        {
+            object obj = null!;
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.Null(obj, "null", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -35,15 +35,24 @@ namespace GuardClauses.UnitTests
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenNullString()
+        {
+            string? nullString = null;
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullString, "nullString", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenEmptyString()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty("", "emptyString"));
         }
+
         [Fact]
         public void ThrowsSelfOwnErrorMessageGivenEmptyString()
         {
-            var ex = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty("", "emptyString", "selfOwnErrorMessage"));
-            Assert.Contains("selfOwnErrorMessage", ex.Message);
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty("", "emptyString", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -52,12 +61,13 @@ namespace GuardClauses.UnitTests
             Guid? nullGuid = null;
             Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullGuid, "nullGuid"));
         }
+
         [Fact]
         public void ThrowsSelfOwnErrorMessageGivenNullGuid()
         {
             Guid? nullGuid = null;
-            var ex = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullGuid, "nullGuid", "selfOwnErrorMessage"));
-            Assert.Contains("selfOwnErrorMessage", ex.Message);
+            var exception = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullGuid, "nullGuid", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -65,11 +75,12 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Guid.Empty, "emptyGuid"));
         }
+
         [Fact]
         public void ThrowsSelfOwnErrorMessageGivenEmptyGuid()
         {
-            var ex = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Guid.Empty, "emptyGuid", "selfOwnErrorMessage"));
-            Assert.Contains("selfOwnErrorMessage", ex.Message);
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Guid.Empty, "emptyGuid", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -77,11 +88,12 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Enumerable.Empty<string>(), "emptyStringEnumerable"));
         }
+
         [Fact]
         public void ThrowsSelfOwnErrorMessageGivenEmptyEnumerable()
         {
-            var ex = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Enumerable.Empty<string>(), "emptyStringEnumerable", "selfOwnErrorMessage"));
-            Assert.Contains("selfOwnErrorMessage", ex.Message);
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Enumerable.Empty<string>(), "emptyStringEnumerable", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrEmpty.cs
@@ -1,4 +1,4 @@
-using Ardalis.GuardClauses;
+﻿using Ardalis.GuardClauses;
 using System;
 using System.Linq;
 using Xunit;
@@ -39,6 +39,12 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty("", "emptyString"));
         }
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenEmptyString()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty("", "emptyString", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
+        }
 
         [Fact]
         public void ThrowsGivenNullGuid()
@@ -46,17 +52,36 @@ namespace GuardClauses.UnitTests
             Guid? nullGuid = null;
             Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullGuid, "nullGuid"));
         }
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenNullGuid()
+        {
+            Guid? nullGuid = null;
+            var ex = Assert.Throws<ArgumentNullException>(() => Guard.Against.NullOrEmpty(nullGuid, "nullGuid", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
+        }
 
         [Fact]
         public void ThrowsGivenEmptyGuid()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Guid.Empty, "emptyGuid"));
         }
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenEmptyGuid()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Guid.Empty, "emptyGuid", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
+        }
 
         [Fact]
         public void ThrowsGivenEmptyEnumerable()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Enumerable.Empty<string>(), "emptyStringEnumerable"));
+        }
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenEmptyEnumerable()
+        {
+            var ex = Assert.Throws<ArgumentException>(() => Guard.Against.NullOrEmpty(Enumerable.Empty<string>(), "emptyStringEnumerable", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
         }
 
         [Fact]
@@ -71,5 +96,6 @@ namespace GuardClauses.UnitTests
             var collection2 = new[] {1, 2};
             Assert.Equal(collection2, Guard.Against.NullOrEmpty(collection2, "intArray"));
         }
+
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -25,9 +25,25 @@ namespace GuardClauses.UnitTests
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenNullValue()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() =>
+                Guard.Against.NullOrWhiteSpace(null, "null", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenEmptyString()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace("", "emptystring"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenEmptyString()
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+                Guard.Against.NullOrWhiteSpace("", "emptystring", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
         }
 
         [Theory]
@@ -35,7 +51,18 @@ namespace GuardClauses.UnitTests
         [InlineData("   ")]
         public void ThrowsGivenWhiteSpaceString(string whiteSpaceString)
         {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring"));
+            Assert.Throws<ArgumentException>(() =>
+                Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring"));
+        }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("   ")]
+        public void ThrowsSelfOwnErrorMessageGivenWhiteSpaceString(string whiteSpaceString)
+        {
+            var ex = Assert.Throws<ArgumentException>(() =>
+                Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
         }
 
         [Theory]
@@ -50,12 +77,5 @@ namespace GuardClauses.UnitTests
             Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "aNumericString"));
         }
 
-        [Theory]
-        [InlineData(" ")]
-        [InlineData("   ")]
-        public void ThrowsSelfOwnErrorMessageWhenGivenWhiteSpaceString(string whiteSpaceString)
-        {
-            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring"));
-        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -27,9 +27,9 @@ namespace GuardClauses.UnitTests
         [Fact]
         public void ThrowsSelfOwnErrorMessageGivenNullValue()
         {
-            var ex = Assert.Throws<ArgumentNullException>(() =>
+            var exception = Assert.Throws<ArgumentNullException>(() =>
                 Guard.Against.NullOrWhiteSpace(null, "null", "selfOwnErrorMessage"));
-            Assert.Contains("selfOwnErrorMessage", ex.Message);
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -41,9 +41,9 @@ namespace GuardClauses.UnitTests
         [Fact]
         public void ThrowsSelfOwnErrorMessageGivenEmptyString()
         {
-            var ex = Assert.Throws<ArgumentException>(() =>
+            var exception = Assert.Throws<ArgumentException>(() =>
                 Guard.Against.NullOrWhiteSpace("", "emptystring", "selfOwnErrorMessage"));
-            Assert.Contains("selfOwnErrorMessage", ex.Message);
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]
@@ -60,9 +60,9 @@ namespace GuardClauses.UnitTests
         [InlineData("   ")]
         public void ThrowsSelfOwnErrorMessageGivenWhiteSpaceString(string whiteSpaceString)
         {
-            var ex = Assert.Throws<ArgumentException>(() =>
+            var exception = Assert.Throws<ArgumentException>(() =>
                 Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring", "selfOwnErrorMessage"));
-            Assert.Contains("selfOwnErrorMessage", ex.Message);
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstNullOrWhiteSpace.cs
@@ -49,5 +49,13 @@ namespace GuardClauses.UnitTests
             Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "string"));
             Assert.Equal(expected, Guard.Against.NullOrWhiteSpace(nonEmptyString, "aNumericString"));
         }
+
+        [Theory]
+        [InlineData(" ")]
+        [InlineData("   ")]
+        public void ThrowsSelfOwnErrorMessageWhenGivenWhiteSpaceString(string whiteSpaceString)
+        {
+            Assert.Throws<ArgumentException>(() => Guard.Against.NullOrWhiteSpace(whiteSpaceString, "whitespacestring"));
+        }
     }
 }

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
@@ -26,12 +26,31 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [InlineData(-1.0, 1.0, 3.0)]
+        [InlineData(0.0, 1.0, 3.0)]
+        [InlineData(4.0, 1.0, 3.0)]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(decimal input, decimal rangeFrom, decimal rangeTo)
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
+        }
+        [Theory]
         [InlineData(-1.0, 3.0, 1.0)]
         [InlineData(0.0, 3.0, 1.0)]
         [InlineData(4.0, 3.0, 1.0)]
         public void ThrowsGivenInvalidArgumentValue(decimal input, decimal rangeFrom, decimal rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [InlineData(-1.0, 3.0, 1.0)]
+        [InlineData(0.0, 3.0, 1.0)]
+        [InlineData(4.0, 3.0, 1.0)]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(decimal input, decimal rangeFrom, decimal rangeTo)
+        {
+            var ex = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDecimal.cs
@@ -31,9 +31,10 @@ namespace GuardClauses.UnitTests
         [InlineData(4.0, 1.0, 3.0)]
         public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(decimal input, decimal rangeFrom, decimal rangeTo)
         {
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
-            Assert.Contains("selfOwnErrorMessage", ex.Message);
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
+
         [Theory]
         [InlineData(-1.0, 3.0, 1.0)]
         [InlineData(0.0, 3.0, 1.0)]
@@ -49,8 +50,8 @@ namespace GuardClauses.UnitTests
         [InlineData(4.0, 3.0, 1.0)]
         public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(decimal input, decimal rangeFrom, decimal rangeTo)
         {
-            var ex = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
-            Assert.Contains("selfOwnErrorMessage", ex.Message);
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
@@ -31,8 +31,8 @@ namespace GuardClauses.UnitTests
         [InlineData(4.0, 1.0, 3.0)]
         public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(double input, double rangeFrom, double rangeTo)
         {
-            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
-            Assert.Contains("selfOwnErrorMessage", ex.Message);
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForDouble.cs
@@ -26,12 +26,32 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [InlineData(-1.0, 1.0, 3.0)]
+        [InlineData(0.0, 1.0, 3.0)]
+        [InlineData(4.0, 1.0, 3.0)]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(double input, double rangeFrom, double rangeTo)
+        {
+            var ex = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
+        }
+
+        [Theory]
         [InlineData(-1.0, 3.0, 1.0)]
         [InlineData(0.0, 3.0, 1.0)]
         [InlineData(4.0, 3.0, 1.0)]
         public void ThrowsGivenInvalidArgumentValue(double input, double rangeFrom, double rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [InlineData(-1.0, 3.0, 1.0)]
+        [InlineData(0.0, 3.0, 1.0)]
+        [InlineData(4.0, 3.0, 1.0)]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(double input, double rangeFrom, double rangeTo)
+        {
+            var ex = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", ex.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
@@ -28,6 +28,15 @@ namespace GuardClauses.UnitTests
             var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange<TestEnum>(enumValue, nameof(enumValue)));
             Assert.Equal(nameof(enumValue), exception.ParamName);
         }
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(6)]
+        [InlineData(10)]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(int enumValue)
+        {
+           var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange<TestEnum>(enumValue, nameof(enumValue), "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
 
         [Theory]
         [InlineData(TestEnum.Budgie)]
@@ -50,6 +59,16 @@ namespace GuardClauses.UnitTests
         {
             var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange(enumValue, nameof(enumValue)));
             Assert.Equal(nameof(enumValue), exception.ParamName);
+        }
+
+        [Theory]
+        [InlineData((TestEnum)(-1))]
+        [InlineData((TestEnum)6)]
+        [InlineData((TestEnum)10)]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeEnum(TestEnum enumValue)
+        {
+            var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange(enumValue, nameof(enumValue), "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnum.cs
@@ -28,6 +28,7 @@ namespace GuardClauses.UnitTests
             var exception = Assert.Throws<InvalidEnumArgumentException>(() => Guard.Against.OutOfRange<TestEnum>(enumValue, nameof(enumValue)));
             Assert.Equal(nameof(enumValue), exception.ParamName);
         }
+
         [Theory]
         [InlineData(-1)]
         [InlineData(6)]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDecimal.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDecimal.cs
@@ -23,10 +23,26 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [ClassData(typeof(IncorrectClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [ClassData(typeof(IncorrectRangeClassData))]
         public void ThrowsGivenInvalidArgumentValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(IEnumerable<decimal> input, decimal rangeFrom, decimal rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDouble.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableDouble.cs
@@ -23,10 +23,26 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [ClassData(typeof(IncorrectClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [ClassData(typeof(IncorrectRangeClassData))]
         public void ThrowsGivenInvalidArgumentValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(IEnumerable<double> input, double rangeFrom, double rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableFloat.cs
@@ -23,10 +23,26 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [ClassData(typeof(IncorrectClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [ClassData(typeof(IncorrectRangeClassData))]
         public void ThrowsGivenInvalidArgumentValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(IEnumerable<float> input, float rangeFrom, float rangeTo)
+        {
+           var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableInt.cs
@@ -23,10 +23,26 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [ClassData(typeof(IncorrectClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+        {
+           var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [ClassData(typeof(IncorrectRangeClassData))]
         public void ThrowsGivenInvalidArgumentValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableLong.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableLong.cs
@@ -23,10 +23,26 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [ClassData(typeof(IncorrectClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [ClassData(typeof(IncorrectRangeClassData))]
         public void ThrowsGivenInvalidArgumentValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(IEnumerable<long> input, long rangeFrom, long rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableShort.cs
@@ -23,10 +23,26 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [ClassData(typeof(IncorrectClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [ClassData(typeof(IncorrectRangeClassData))]
         public void ThrowsGivenInvalidArgumentValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo));
+        }
+        
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(IEnumerable<short> input, short rangeFrom, short rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, nameof(input), rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForEnumerableTimeSpan.cs
@@ -32,6 +32,18 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [ClassData(typeof(IncorrectClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+        {
+            var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
+            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+
+           var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [ClassData(typeof(IncorrectRangeClassData))]
         public void ThrowsGivenInvalidArgumentValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
         {
@@ -40,6 +52,18 @@ namespace GuardClauses.UnitTests
             var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
 
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan));
+        }
+
+        [Theory]
+        [ClassData(typeof(IncorrectRangeClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(IEnumerable<int> input, int rangeFrom, int rangeTo)
+        {
+            var inputTimeSpan = input.Select(i => TimeSpan.FromSeconds(i));
+            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+            
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, nameof(inputTimeSpan), rangeFromTimeSpan, rangeToTimeSpan, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForFloat.cs
@@ -26,12 +26,32 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [InlineData(-1.0, 1.0, 3.0)]
+        [InlineData(0.0, 1.0, 3.0)]
+        [InlineData(4.0, 1.0, 3.0)]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(float input, float rangeFrom, float rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [InlineData(-1.0, 3.0, 1.0)]
         [InlineData(0.0, 3.0, 1.0)]
         [InlineData(4.0, 3.0, 1.0)]
         public void ThrowsGivenInvalidArgumentValue(float input, float rangeFrom, float rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [InlineData(-1.0, 3.0, 1.0)]
+        [InlineData(0.0, 3.0, 1.0)]
+        [InlineData(4.0, 3.0, 1.0)]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(float input, float rangeFrom, float rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInt.cs
@@ -26,12 +26,32 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [InlineData(-1, 1, 3)]
+        [InlineData(0, 1, 3)]
+        [InlineData(4, 1, 3)]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [InlineData(-1, 3, 1)]
         [InlineData(0, 3, 1)]
         [InlineData(4, 3, 1)]
         public void ThrowsGivenInvalidArgumentValue(int input, int rangeFrom, int rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [InlineData(-1, 3, 1)]
+        [InlineData(0, 3, 1)]
+        [InlineData(4, 3, 1)]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(int input, int rangeFrom, int rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForInvalidInput.cs
@@ -24,6 +24,14 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [ClassData(typeof(IncorrectClassData))]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue<T>(T input, Func<T, bool> func)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.InvalidInput(input, nameof(input), func, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [ClassData(typeof(CorrectClassData))]
         public void ReturnsExpectedValueGivenInRangeValue<T>(T input, Func<T, bool> func)
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForShort.cs
@@ -26,12 +26,32 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [InlineData(-1, 1, 3)]
+        [InlineData(0, 1, 3)]
+        [InlineData(4, 1, 3)]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(short input, short rangeFrom, short rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [InlineData(-1, 3, 1)]
         [InlineData(0, 3, 1)]
         [InlineData(4, 3, 1)]
         public void ThrowsGivenInvalidArgumentValue(short input, short rangeFrom, short rangeTo)
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo));
+        }
+
+        [Theory]
+        [InlineData(-1, 3, 1)]
+        [InlineData(0, 3, 1)]
+        [InlineData(4, 3, 1)]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(short input, short rangeFrom, short rangeTo)
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(input, "index", rangeFrom, rangeTo, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfRangeForTimeSpan.cs
@@ -34,6 +34,20 @@ namespace GuardClauses.UnitTests
         }
 
         [Theory]
+        [InlineData(-1, 1, 3)]
+        [InlineData(0, 1, 3)]
+        [InlineData(4, 1, 3)]
+        public void ThrowsSelfOwnErrorMessageGivenOutOfRangeValue(int input, int rangeFrom, int rangeTo)
+        {
+            var inputTimeSpan = TimeSpan.FromSeconds(input);
+            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Theory]
         [InlineData(-1, 3, 1)]
         [InlineData(0, 3, 1)]
         [InlineData(4, 3, 1)]
@@ -44,6 +58,20 @@ namespace GuardClauses.UnitTests
             var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
 
             Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan));
+        }
+
+        [Theory]
+        [InlineData(-1, 3, 1)]
+        [InlineData(0, 3, 1)]
+        [InlineData(4, 3, 1)]
+        public void ThrowsSelfOwnErrorMessageGivenInvalidArgumentValue(int input, int rangeFrom, int rangeTo)
+        {
+            var inputTimeSpan = TimeSpan.FromSeconds(input);
+            var rangeFromTimeSpan = TimeSpan.FromSeconds(rangeFrom);
+            var rangeToTimeSpan = TimeSpan.FromSeconds(rangeTo);
+
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.OutOfRange(inputTimeSpan, "index", rangeFromTimeSpan, rangeToTimeSpan, "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Theory]

--- a/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstOutOfSQLDateRange.cs
@@ -23,6 +23,21 @@ namespace GuardClauses.UnitTests
             Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date)));
         }
 
+        [Theory]
+        [InlineData(1)]
+        [InlineData(60)]
+        [InlineData(60 * 60)]
+        [InlineData(60 * 60 * 24)]
+        [InlineData(60 * 60 * 24 * 30)]
+        [InlineData(60 * 60 * 24 * 30 * 365)]
+        public void ThrowsSelfOwnErrorMessageGivenValueBelowMinDate(int offsetInSeconds)
+        {
+            DateTime date = SqlDateTime.MinValue.Value.AddSeconds(-offsetInSeconds);
+
+            var exception = Assert.Throws<ArgumentOutOfRangeException>(() => Guard.Against.OutOfSQLDateRange(date, nameof(date), "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
         [Fact]
         public void DoNothingGivenCurrentDate()
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstZero.cs
@@ -28,6 +28,7 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0, "zero"));
         }
+
         [Fact]
         public void ThrowsSelfOwnErrorMessageGivenZeroValueIntZero()
         {

--- a/test/GuardClauses.UnitTests/GuardAgainstZero.cs
+++ b/test/GuardClauses.UnitTests/GuardAgainstZero.cs
@@ -1,4 +1,4 @@
-using Ardalis.GuardClauses;
+﻿using Ardalis.GuardClauses;
 using System;
 using Xunit;
 
@@ -28,11 +28,24 @@ namespace GuardClauses.UnitTests
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0, "zero"));
         }
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueIntZero()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0, "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
 
         [Fact]
         public void ThrowsGivenZeroValueLongZero()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0L, "zero"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueLongZero()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0L, "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -42,9 +55,23 @@ namespace GuardClauses.UnitTests
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueDecimalZero()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0M, "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenZeroValueFloatZero()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0f, "zero"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueFloatZero()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0f, "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -53,12 +80,24 @@ namespace GuardClauses.UnitTests
             Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0, "zero"));
         }
 
-
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueDoubleZero()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(0.0, "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
 
         [Fact]
         public void ThrowsGivenZeroValueDefaultInt()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(int), "zero"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueDefaultInt()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(int), "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -68,9 +107,23 @@ namespace GuardClauses.UnitTests
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueDefaultLong()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(long), "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenZeroValueDefaultDecimal()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(decimal), "zero"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueDefaultDecimal()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(decimal), "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]
@@ -80,16 +133,36 @@ namespace GuardClauses.UnitTests
         }
 
         [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueDefaultFloat()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(float), "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
+
+        [Fact]
         public void ThrowsGivenZeroValueDefaultDouble()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(double), "zero"));
         }
 
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueDefaultDouble()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(default(double), "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
+        }
 
         [Fact]
         public void ThrowsGivenZeroValueDecimalDotZero()
         {
             Assert.Throws<ArgumentException>(() => Guard.Against.Zero(decimal.Zero, "zero"));
+        }
+
+        [Fact]
+        public void ThrowsSelfOwnErrorMessageGivenZeroValueDecimalDotZero()
+        {
+            var exception = Assert.Throws<ArgumentException>(() => Guard.Against.Zero(decimal.Zero, "zero", "selfOwnErrorMessage"));
+            Assert.Contains("selfOwnErrorMessage", exception.Message);
         }
 
         [Fact]


### PR DESCRIPTION
- add unit test:NullOrEmpty
- add unit test:NullOrWhiteSpace
- add unit test:OutOfRangeForDecimal
- add unit test:OutOfRangeForDouble
- add unit test:OutOfRangeForEnum
- add unit test:OutOfRangeForEnumerableDecimal
- add unit test:OutOfRangeForEnumerableDouble
- add unit test:OutOfRangeForEnumerableFloat
- add unit test:OutOfRangeForEnumerableInt
- add unit test:OutOfRangeForEnumerableLong
- add unit test:OutOfRangeForEnumerableShort
- add unit test:OutOfRangeForEnumerableTimeSpan
- add unit test:OutOfRangeForFloat
- add unit test:OutOfRangeForInt
- add unit test:OutOfRangeForInvalidInput
- add unit test:OutOfRangeForShort
- add unit test:OutOfRangeForTimeSpan
- add unit test:OutOfSQLDateRange
- add unit test:Zero
- add unit test:Default
- add unit test:InvalidFormat
- add unit test:Negative
- add unit test:NegativeOrZero
- add unit test:Null
- fix spacing
